### PR TITLE
Add simple Flask web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,20 @@ pip install git+https://github.com/lapis42/srtgo -U
 
 [?] 예약 취소 (Enter: 결정): [SRT] 01월 04일, 수서~동대구(13:00~14:46) 36800원(1석), 구입기한 01월 03일 16:57
  > [SRT] 01월 04일, 수서~동대구(13:00~14:46) 36800원(1석), 구입기한 01월 03일 16:57
-   텔레그램으로 예매 정보 전송
-   돌아가기
+  텔레그램으로 예매 정보 전송
+  돌아가기
 ```
+
+## Running the Web Server
+
+Install the optional `web` extras and start the server:
+
+```bash
+pip install .[web]
+srtgo-web
+```
+
+The Flask server provides REST endpoints on port `8000`.
 
 ## Acknowledgments
 - This project includes code from [SRT](https://github.com/ryanking13/SRT) by ryanking13, licensed under the MIT License, and [korail2](https://github.com/carpedm20/korail2) by carpedm20, licensed under the BSD License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "requests",
     "termcolor"
 ]
+optional-dependencies = { web = ["flask"] }
 dynamic = ["version"]
 [tool.setuptools_scm]
 
@@ -32,3 +33,4 @@ Homepage = "https://github.com/lapis42/srtgo"
 
 [project.scripts]
 srtgo = "srtgo.srtgo:srtgo"
+srtgo-web = "webapp.app:main"

--- a/srtgo/core.py
+++ b/srtgo/core.py
@@ -1,0 +1,127 @@
+import keyring
+from .srtgo import login as _cli_login, pay_card as _cli_pay_card
+from .srt import SRT, SeatType
+from .ktx import Korail, ReserveOption, AdultPassenger, ChildPassenger, SeniorPassenger, Disability1To3Passenger, Disability4To6Passenger
+
+__all__ = [
+    "login", "set_login_credentials", "search_trains", "reserve_train",
+    "get_reservations", "cancel_reservation",
+    "set_card_info", "set_telegram_info", "set_station_info", "set_option_settings",
+]
+
+
+def set_login_credentials(rail_type: str, user_id: str, password: str, debug: bool = False) -> bool:
+    """Store user login credentials after verifying."""
+    try:
+        if rail_type == "SRT":
+            SRT(user_id, password, verbose=debug)
+        else:
+            Korail(user_id, password, verbose=debug)
+    except Exception:
+        return False
+
+    keyring.set_password(rail_type, "id", user_id)
+    keyring.set_password(rail_type, "pass", password)
+    keyring.set_password(rail_type, "ok", "1")
+    return True
+
+
+def login(rail_type: str = "SRT", debug: bool = False):
+    """Login using stored credentials."""
+    return _cli_login(rail_type=rail_type, debug=debug)
+
+
+def search_trains(rail_type: str, departure: str, arrival: str, date: str, time: str):
+    rail = login(rail_type)
+    return rail.search_train(departure, arrival, date, time)
+
+
+def _build_passengers(rail_type: str, counts: dict):
+    if rail_type == "SRT":
+        from .srt import Adult, Child, Senior, Disability1To3, Disability4To6
+        cls_map = {
+            "adult": Adult,
+            "child": Child,
+            "senior": Senior,
+            "disability1to3": Disability1To3,
+            "disability4to6": Disability4To6,
+        }
+    else:
+        cls_map = {
+            "adult": AdultPassenger,
+            "child": ChildPassenger,
+            "senior": SeniorPassenger,
+            "disability1to3": Disability1To3Passenger,
+            "disability4to6": Disability4To6Passenger,
+        }
+    passengers = []
+    for key, cls in cls_map.items():
+        cnt = int(counts.get(key, 0))
+        if cnt:
+            passengers.append(cls(cnt))
+    return passengers
+
+
+def reserve_train(
+    rail_type: str,
+    departure: str,
+    arrival: str,
+    date: str,
+    time: str,
+    passengers: dict | None = None,
+    seat_type: str | None = None,
+    pay: bool = False,
+):
+    rail = login(rail_type)
+    trains = rail.search_train(departure, arrival, date, time)
+    if not trains:
+        raise RuntimeError("No trains found")
+    train = trains[0]
+    passengers = _build_passengers(rail_type, passengers or {"adult": 1})
+    if rail_type == "SRT":
+        option = SeatType[seat_type] if seat_type else SeatType.GENERAL_FIRST
+    else:
+        option = ReserveOption[seat_type] if seat_type else ReserveOption.GENERAL_FIRST
+    reservation = rail.reserve(train, passengers=passengers, option=option)
+    if pay and not getattr(reservation, "is_waiting", False):
+        _cli_pay_card(rail, reservation)
+    return reservation
+
+
+def get_reservations(rail_type: str):
+    rail = login(rail_type)
+    if rail_type == "SRT":
+        return rail.get_reservations()
+    return rail.reservations()
+
+
+def cancel_reservation(rail_type: str, reservation):
+    rail = login(rail_type)
+    if rail_type == "SRT":
+        rail.cancel(reservation)
+    else:
+        rail.cancel(reservation)
+
+
+# Settings helpers
+
+def set_card_info(number: str, password: str, birthday: str, expire: str):
+    keyring.set_password("card", "number", number)
+    keyring.set_password("card", "password", password)
+    keyring.set_password("card", "birthday", birthday)
+    keyring.set_password("card", "expire", expire)
+    keyring.set_password("card", "ok", "1")
+
+
+def set_telegram_info(token: str, chat_id: str):
+    keyring.set_password("telegram", "token", token)
+    keyring.set_password("telegram", "chat_id", chat_id)
+    keyring.set_password("telegram", "ok", "1")
+
+
+def set_station_info(rail_type: str, stations: list[str]):
+    keyring.set_password(rail_type, "station", ",".join(stations))
+
+
+def set_option_settings(options: list[str]):
+    keyring.set_password("SRT", "options", ",".join(options))

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,107 @@
+from flask import Flask, request, jsonify
+
+from srtgo.core import (
+    set_login_credentials,
+    reserve_train,
+    search_trains,
+    get_reservations,
+    cancel_reservation,
+    set_card_info,
+    set_telegram_info,
+    set_station_info,
+    set_option_settings,
+)
+
+app = Flask(__name__)
+
+
+@app.post("/login")
+def login_route():
+    data = request.get_json(force=True)
+    rail_type = data.get("rail_type", "SRT")
+    if set_login_credentials(rail_type, data["id"], data["password"]):
+        return jsonify({"status": "ok"})
+    return jsonify({"status": "fail"}), 400
+
+
+@app.get("/reserve")
+def search_route():
+    rail_type = request.args.get("rail_type", "SRT")
+    dep = request.args["departure"]
+    arr = request.args["arrival"]
+    date = request.args["date"]
+    time = request.args.get("time", "000000")
+    trains = search_trains(rail_type, dep, arr, date, time)
+    return jsonify([str(t) for t in trains])
+
+
+@app.post("/reserve")
+def reserve_route():
+    data = request.get_json(force=True)
+    rail_type = data.get("rail_type", "SRT")
+    reservation = reserve_train(
+        rail_type,
+        data["departure"],
+        data["arrival"],
+        data["date"],
+        data.get("time", "000000"),
+        data.get("passengers"),
+        data.get("seat_type"),
+        data.get("pay", False),
+    )
+    return jsonify({"reservation": str(reservation)})
+
+
+@app.get("/reservations")
+def list_reservations():
+    rail_type = request.args.get("rail_type", "SRT")
+    res = get_reservations(rail_type)
+    return jsonify([str(r) for r in res])
+
+
+@app.delete("/reservations/<pnr>")
+def cancel(pnr):
+    rail_type = request.args.get("rail_type", "SRT")
+    res_list = get_reservations(rail_type)
+    for r in res_list:
+        if getattr(r, "reservation_number", None) == pnr:
+            cancel_reservation(rail_type, r)
+            return jsonify({"status": "ok"})
+    return jsonify({"status": "not_found"}), 404
+
+
+@app.post("/settings/card")
+def card_settings():
+    data = request.get_json(force=True)
+    set_card_info(data["number"], data["password"], data["birthday"], data["expire"])
+    return jsonify({"status": "ok"})
+
+
+@app.post("/settings/telegram")
+def telegram_settings():
+    data = request.get_json(force=True)
+    set_telegram_info(data["token"], data["chat_id"])
+    return jsonify({"status": "ok"})
+
+
+@app.post("/settings/stations")
+def station_settings():
+    data = request.get_json(force=True)
+    rail_type = data.get("rail_type", "SRT")
+    set_station_info(rail_type, data.get("stations", []))
+    return jsonify({"status": "ok"})
+
+
+@app.post("/settings/options")
+def option_settings():
+    data = request.get_json(force=True)
+    set_option_settings(data.get("options", []))
+    return jsonify({"status": "ok"})
+
+
+def main():
+    app.run(host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add optional Flask web app with basic routes
- expose helper functions for login, reservations and settings
- allow installing `srtgo[web]` for web support
- document how to run the server

## Testing
- `python -m py_compile webapp/app.py srtgo/core.py`

------
https://chatgpt.com/codex/tasks/task_e_6841fd880744832585482a4f47550c96