### PR TITLE
Add JSON helpers and update web API

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,5 +178,26 @@ srtgo-web
 
 The Flask server provides REST endpoints on port `8000`.
 
+Example usage:
+
+```bash
+curl "http://localhost:8000/reserve?departure=수서&arrival=부산&date=20240101"
+```
+
+This returns a JSON list of trains, for example:
+
+```json
+[
+  {
+    "train_number": "333",
+    "dep_time": "1250",
+    "arr_time": "1434",
+    "general_seat_state": "매진"
+  }
+]
+```
+
+A POST request to `/reserve` returns reservation details in a JSON object.
+
 ## Acknowledgments
 - This project includes code from [SRT](https://github.com/ryanking13/SRT) by ryanking13, licensed under the MIT License, and [korail2](https://github.com/carpedm20/korail2) by carpedm20, licensed under the BSD License.

--- a/srtgo/ktx.py
+++ b/srtgo/ktx.py
@@ -101,6 +101,30 @@ class Train(Schedule):
                 repr_str += f", 예약대기 {'가능' if self.has_general_waiting_list() else '매진'}"
         return repr_str
 
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the train."""
+        return {
+            "train_type": self.train_type,
+            "train_type_name": self.train_type_name,
+            "train_group": self.train_group,
+            "train_no": self.train_no,
+            "delay_time": self.delay_time,
+            "dep_name": self.dep_name,
+            "dep_code": self.dep_code,
+            "dep_date": self.dep_date,
+            "dep_time": self.dep_time,
+            "arr_name": self.arr_name,
+            "arr_code": self.arr_code,
+            "arr_date": self.arr_date,
+            "arr_time": self.arr_time,
+            "run_date": self.run_date,
+            "reserve_possible": self.reserve_possible,
+            "reserve_possible_name": self.reserve_possible_name,
+            "special_seat": self.special_seat,
+            "general_seat": self.general_seat,
+            "wait_reserve_flag": self.wait_reserve_flag,
+        }
+
     def has_special_seat(self):
         return self.special_seat == '11'
 
@@ -147,6 +171,23 @@ class Ticket(Train):
     def get_ticket_no(self):
         return "-".join(map(str, (self.sale_info1, self.sale_info2, self.sale_info3, self.sale_info4)))
 
+    def to_dict(self) -> dict:
+        """Return ticket information as a dictionary."""
+        return {
+            "seat_no_end": self.seat_no_end,
+            "seat_no_count": self.seat_no_count,
+            "buyer_name": self.buyer_name,
+            "sale_date": self.sale_date,
+            "pnr_no": self.pnr_no,
+            "sale_info1": self.sale_info1,
+            "sale_info2": self.sale_info2,
+            "sale_info3": self.sale_info3,
+            "sale_info4": self.sale_info4,
+            "price": self.price,
+            "car_no": self.car_no,
+            "seat_no": self.seat_no,
+        }
+
 class Reservation(Train):
     """Train reservation information"""
     def __init__(self, data):
@@ -173,6 +214,33 @@ class Reservation(Train):
             buy_limit_date = f"{int(self.buy_limit_date[4:6])}월 {int(self.buy_limit_date[6:])}일"
             repr_str += f", 구입기한 {buy_limit_date} {buy_limit_time}"
         return repr_str
+
+    def to_dict(self) -> dict:
+        """Return reservation information as a dictionary."""
+        return {
+            "dep_date": self.dep_date,
+            "arr_date": self.arr_date,
+            "rsv_id": self.rsv_id,
+            "seat_no_count": self.seat_no_count,
+            "buy_limit_date": self.buy_limit_date,
+            "buy_limit_time": self.buy_limit_time,
+            "price": self.price,
+            "journey_no": self.journey_no,
+            "journey_cnt": self.journey_cnt,
+            "rsv_chg_no": self.rsv_chg_no,
+            "is_waiting": self.is_waiting,
+            "train_type": self.train_type,
+            "train_type_name": self.train_type_name,
+            "train_group": self.train_group,
+            "train_no": self.train_no,
+            "dep_name": self.dep_name,
+            "dep_code": self.dep_code,
+            "dep_time": self.dep_time,
+            "arr_name": self.arr_name,
+            "arr_code": self.arr_code,
+            "arr_time": self.arr_time,
+            "run_date": self.run_date,
+        }
 
 
 # Passenger classes

--- a/srtgo/srt.py
+++ b/srtgo/srt.py
@@ -286,6 +286,21 @@ class SRTTicket:
             f"[{self.price}원({self.discount}원 할인)]"
         )
 
+    def to_dict(self) -> dict:
+        """Return ticket information as a dictionary."""
+        return {
+            "car": self.car,
+            "seat": self.seat,
+            "seat_type_code": self.seat_type_code,
+            "seat_type": self.seat_type,
+            "passenger_type_code": self.passenger_type_code,
+            "passenger_type": self.passenger_type,
+            "price": self.price,
+            "original_price": self.original_price,
+            "discount": self.discount,
+            "is_waiting": self.is_waiting,
+        }
+
 
 class SRTReservation:
     def __init__(self, train, pay, tickets):
@@ -318,6 +333,30 @@ class SRTReservation:
         return self.dump()
 
     __repr__ = __str__
+
+    def to_dict(self) -> dict:
+        """Return reservation details as a dictionary."""
+        return {
+            "reservation_number": self.reservation_number,
+            "total_cost": self.total_cost,
+            "seat_count": self.seat_count,
+            "train_code": self.train_code,
+            "train_name": self.train_name,
+            "train_number": self.train_number,
+            "dep_date": self.dep_date,
+            "dep_time": self.dep_time,
+            "dep_station_code": self.dep_station_code,
+            "dep_station_name": self.dep_station_name,
+            "arr_time": self.arr_time,
+            "arr_station_code": self.arr_station_code,
+            "arr_station_name": self.arr_station_name,
+            "payment_date": self.payment_date,
+            "payment_time": self.payment_time,
+            "paid": self.paid,
+            "is_running": self.is_running,
+            "is_waiting": self.is_waiting,
+            "tickets": [t.__dict__ for t in self._tickets],
+        }
 
     def dump(self):
         base = (
@@ -440,6 +479,26 @@ class SRTTrain(Train):
 
     def __repr__(self):
         return self.dump()
+
+    def to_dict(self) -> dict:
+        """Return a dictionary representation of the train."""
+        return {
+            "train_code": self.train_code,
+            "train_name": self.train_name,
+            "train_number": self.train_number,
+            "dep_date": self.dep_date,
+            "dep_time": self.dep_time,
+            "dep_station_code": self.dep_station_code,
+            "dep_station_name": self.dep_station_name,
+            "arr_date": self.arr_date,
+            "arr_time": self.arr_time,
+            "arr_station_code": self.arr_station_code,
+            "arr_station_name": self.arr_station_name,
+            "general_seat_state": self.general_seat_state,
+            "special_seat_state": self.special_seat_state,
+            "reserve_wait_possible_name": self.reserve_wait_possible_name,
+            "reserve_wait_possible_code": self.reserve_wait_possible_code,
+        }
 
     def dump(self):
         dep_hour, dep_min = self.dep_time[0:2], self.dep_time[2:4]

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -32,7 +32,7 @@ def search_route():
     date = request.args["date"]
     time = request.args.get("time", "000000")
     trains = search_trains(rail_type, dep, arr, date, time)
-    return jsonify([str(t) for t in trains])
+    return jsonify([getattr(t, "to_dict", lambda: t.__dict__)() for t in trains])
 
 
 @app.post("/reserve")
@@ -49,14 +49,14 @@ def reserve_route():
         data.get("seat_type"),
         data.get("pay", False),
     )
-    return jsonify({"reservation": str(reservation)})
+    return jsonify({"reservation": getattr(reservation, "to_dict", lambda: reservation.__dict__)()})
 
 
 @app.get("/reservations")
 def list_reservations():
     rail_type = request.args.get("rail_type", "SRT")
     res = get_reservations(rail_type)
-    return jsonify([str(r) for r in res])
+    return jsonify([getattr(r, "to_dict", lambda: r.__dict__)() for r in res])
 
 
 @app.delete("/reservations/<pnr>")


### PR DESCRIPTION
## Summary
- expose `to_dict()` helpers for trains and reservations
- return structured JSON from the web server
- document updated JSON output in README

## Testing
- `python -m py_compile srtgo/*.py webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68420343c6788325b7a18a5600c28418