### PR TITLE
Add pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,15 @@ Include this token in the `X-Auth-Token` header for all requests. To
 generate a new token, send a `POST` request to `/token` with the current
 token in the header.
 
+## Running Tests
+
+Install the development extras and run `pytest`:
+
+```bash
+pip install .[dev]
+pytest
+```
+
 
 ## Acknowledgments
 - This project includes code from [SRT](https://github.com/ryanking13/SRT) by ryanking13, licensed under the MIT License, and [korail2](https://github.com/carpedm20/korail2) by carpedm20, licensed under the BSD License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "requests",
     "termcolor"
 ]
-optional-dependencies = { web = ["flask"] }
+optional-dependencies = { web = ["flask"], dev = ["pytest"] }
 dynamic = ["version"]
 [tool.setuptools_scm]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,52 @@
+import os, sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from unittest.mock import patch
+
+from srtgo import core
+
+
+def test_set_login_credentials_success():
+    with patch.object(core, 'SRT') as srt_cls, patch.object(core, 'keyring') as kr:
+        assert core.set_login_credentials('SRT', 'uid', 'pwd') is True
+        srt_cls.assert_called_with('uid', 'pwd', verbose=False)
+        kr.set_password.assert_any_call('SRT', 'id', 'uid')
+        kr.set_password.assert_any_call('SRT', 'pass', 'pwd')
+
+
+def test_set_login_credentials_failure():
+    with patch.object(core, 'SRT', side_effect=Exception), patch.object(core, 'keyring') as kr:
+        assert core.set_login_credentials('SRT', 'uid', 'pwd') is False
+        kr.set_password.assert_not_called()
+
+
+def test_search_trains():
+    stub = SimpleNamespace(search_train=lambda d, a, dt, tm: ['t'])
+    with patch.object(core, 'login', return_value=stub) as login_mock:
+        result = core.search_trains('SRT', 'A', 'B', '20230101', '0000')
+        assert result == ['t']
+        login_mock.assert_called_once_with('SRT')
+
+
+def test_reserve_train_with_pay():
+    rail = SimpleNamespace(
+        search_train=lambda *args, **kwargs: ['train'],
+        reserve=lambda *args, **kwargs: SimpleNamespace(is_waiting=False)
+    )
+    with (
+        patch.object(core, 'login', return_value=rail),
+        patch.object(core, '_build_passengers', return_value=['p']),
+        patch.object(core, '_cli_pay_card') as pay_mock
+    ):
+        core.reserve_train('SRT', 'A', 'B', '20230101', '0900', pay=True)
+        pay_mock.assert_called_once()
+
+
+def test_reserve_train_no_trains():
+    rail = SimpleNamespace(search_train=lambda *args, **kwargs: [])
+    with patch.object(core, 'login', return_value=rail):
+        with pytest.raises(RuntimeError):
+            core.reserve_train('SRT', 'A', 'B', '20230101', '0000')

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,9 +1,13 @@
 import os, sys
+
+# Use an in-memory keyring so tests don't require system backends
+os.environ.setdefault("PYTHON_KEYRING_BACKEND", "keyring.backends.null.Keyring")
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import pytest
 from unittest.mock import patch
 
-from webapp.app import app
+from webapp.app import app, AUTH_TOKEN
 
 @pytest.fixture()
 def client():
@@ -13,17 +17,49 @@ def client():
 
 def test_login_invalid(client):
     with patch('webapp.app.set_login_credentials', return_value=False):
-        resp = client.post('/login', json={'id': 'u', 'password': 'p'})
+        resp = client.post(
+            '/login',
+            json={'id': 'u', 'password': 'p'},
+            headers={'X-Auth-Token': AUTH_TOKEN}
+        )
         assert resp.status_code == 400
         assert resp.get_json()['message'] == 'Invalid credentials'
 
 def test_search_internal_error(client):
     with patch('webapp.app.search_trains', side_effect=RuntimeError('boom')):
-        resp = client.get('/reserve?departure=A&arrival=B&date=20230101')
+        resp = client.get(
+            '/reserve?departure=A&arrival=B&date=20230101',
+            headers={'X-Auth-Token': AUTH_TOKEN}
+        )
         assert resp.status_code == 500
         assert resp.get_json()['message'] == 'boom'
 
 def test_card_settings_missing_field(client):
-    resp = client.post('/settings/card', json={'password': 'p'})
+    resp = client.post(
+        '/settings/card',
+        json={'password': 'p'},
+        headers={'X-Auth-Token': AUTH_TOKEN}
+    )
+    assert resp.status_code == 400
+    assert 'Missing field' in resp.get_json()['message']
+
+
+def test_login_success(client):
+    with patch('webapp.app.set_login_credentials', return_value=True):
+        resp = client.post(
+            '/login',
+            json={'id': 'u', 'password': 'p'},
+            headers={'X-Auth-Token': AUTH_TOKEN}
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()['message'] == 'ok'
+
+
+def test_reserve_missing_field(client):
+    resp = client.post(
+        '/reserve',
+        json={'departure': 'A'},
+        headers={'X-Auth-Token': AUTH_TOKEN}
+    )
     assert resp.status_code == 400
     assert 'Missing field' in resp.get_json()['message']


### PR DESCRIPTION
## Summary
- add pytest dev extra
- document how to run tests
- create tests for core helpers and web API
- update web tests to use auth token

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842060eb8d48325ac97ef414271b58d