### PR TITLE
Add seat filtering options in reserve search

### DIFF
--- a/api.md
+++ b/api.md
@@ -35,6 +35,8 @@ Search for trains.
 - `date` (string, required, format `YYYYMMDD`)
 - `time` (string, optional, `HHMMSS`, default `000000`)
 - `rail_type` (string, optional, default `SRT`)
+- `include_no_seats` (boolean, optional)
+- `include_waiting_list` (boolean, optional)
 
 ### Sample Response
 ```json

--- a/srtgo/core.py
+++ b/srtgo/core.py
@@ -31,9 +31,32 @@ def login(rail_type: str = "SRT", debug: bool = False):
     return _cli_login(rail_type=rail_type, debug=debug)
 
 
-def search_trains(rail_type: str, departure: str, arrival: str, date: str, time: str):
+def search_trains(
+    rail_type: str,
+    departure: str,
+    arrival: str,
+    date: str,
+    time: str,
+    include_no_seats: bool = False,
+    include_waiting_list: bool = False,
+):
     rail = login(rail_type)
-    return rail.search_train(departure, arrival, date, time)
+    if rail_type == "SRT":
+        return rail.search_train(
+            departure,
+            arrival,
+            date,
+            time,
+            available_only=not include_no_seats,
+        )
+    return rail.search_train(
+        departure,
+        arrival,
+        date,
+        time,
+        include_no_seats=include_no_seats,
+        include_waiting_list=include_waiting_list,
+    )
 
 
 def _build_passengers(rail_type: str, counts: dict):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ def test_set_login_credentials_failure():
 
 
 def test_search_trains():
-    stub = SimpleNamespace(search_train=lambda d, a, dt, tm: ['t'])
+    stub = SimpleNamespace(search_train=lambda *args, **kwargs: ['t'])
     with patch.object(core, 'login', return_value=stub) as login_mock:
         result = core.search_trains('SRT', 'A', 'B', '20230101', '0000')
         assert result == ['t']

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -63,3 +63,29 @@ def test_reserve_missing_field(client):
     )
     assert resp.status_code == 400
     assert 'Missing field' in resp.get_json()['message']
+
+
+def test_search_default_flags(client):
+    with patch('webapp.app.search_trains', return_value=[]) as mock:
+        resp = client.get(
+            '/reserve?departure=A&arrival=B&date=20230101',
+            headers={'X-Auth-Token': AUTH_TOKEN}
+        )
+        assert resp.status_code == 200
+        mock.assert_called_once_with(
+            'SRT', 'A', 'B', '20230101', '000000',
+            include_no_seats=False, include_waiting_list=False
+        )
+
+
+def test_search_flags_forwarded(client):
+    with patch('webapp.app.search_trains', return_value=[]) as mock:
+        resp = client.get(
+            '/reserve?departure=A&arrival=B&date=20230101&rail_type=KTX&include_no_seats=1&include_waiting_list=true',
+            headers={'X-Auth-Token': AUTH_TOKEN}
+        )
+        assert resp.status_code == 200
+        mock.assert_called_once_with(
+            'KTX', 'A', 'B', '20230101', '000000',
+            include_no_seats=True, include_waiting_list=True
+        )

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -78,7 +78,19 @@ def search_route():
         arr = request.args["arrival"]
         date = request.args["date"]
         time = request.args.get("time", "000000")
-        trains = search_trains(rail_type, dep, arr, date, time)
+        inc_no = request.args.get("include_no_seats")
+        inc_wait = request.args.get("include_waiting_list")
+        include_no_seats = str(inc_no).lower() in ("1", "true", "yes")
+        include_waiting_list = str(inc_wait).lower() in ("1", "true", "yes")
+        trains = search_trains(
+            rail_type,
+            dep,
+            arr,
+            date,
+            time,
+            include_no_seats=include_no_seats,
+            include_waiting_list=include_waiting_list,
+        )
         return jsonify([getattr(t, "to_dict", lambda: t.__dict__)() for t in trains])
     except KeyError as exc:
         return jsonify({"message": f"Missing parameter: {exc.args[0]}"}), 400


### PR DESCRIPTION
## Summary
- support `include_no_seats` and `include_waiting_list` parameters for `/reserve` GET
- pass new flags through `core.search_trains`
- document new query parameters
- update core tests for new signature
- ensure webapp forwards flags correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420c8064108325ad5f81efb7556251