### PR TITLE
Add minimal web frontend with service worker

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,7 +1,7 @@
 import functools
 import secrets
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 from flasgger import Swagger
 import keyring
 from keyring.errors import KeyringError
@@ -18,7 +18,7 @@ from srtgo.core import (
     set_option_settings,
 )
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder="static", static_url_path="")
 Swagger(app)
 
 TOKEN_SERVICE = "webapp"
@@ -41,6 +41,11 @@ def _ensure_token() -> str:
 
 
 AUTH_TOKEN = _ensure_token()
+
+
+@app.get("/")
+def index_page():
+    return app.send_static_file("index.html")
 
 
 def require_auth(func):

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SRTgo Web</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+  <nav id="nav">
+    <button data-view="login">Login</button>
+    <button data-view="search">Search</button>
+    <button data-view="reservations">Reservations</button>
+    <button data-view="settings">Settings</button>
+  </nav>
+  <div id="token-box">
+    <label>Auth Token <input id="auth-token"></label>
+    <button id="save-token">Save</button>
+  </div>
+</header>
+<main>
+  <section id="login" class="view">
+    <h2>Login</h2>
+    <form id="login-form">
+      <label>User ID <input id="login-id" required></label>
+      <label>Password <input id="login-password" type="password" required></label>
+      <label>Rail Type
+        <select id="login-rail">
+          <option value="SRT">SRT</option>
+          <option value="KTX">KTX</option>
+        </select>
+      </label>
+      <button type="submit">Save</button>
+    </form>
+  </section>
+
+  <section id="search" class="view hidden">
+    <h2>Search Trains</h2>
+    <form id="search-form">
+      <label>Departure <input id="search-departure" required></label>
+      <label>Arrival <input id="search-arrival" required></label>
+      <label>Date <input id="search-date" type="date" required></label>
+      <label>Time <input id="search-time" type="time" value="00:00"></label>
+      <label>Rail Type
+        <select id="search-rail">
+          <option value="SRT">SRT</option>
+          <option value="KTX">KTX</option>
+        </select>
+      </label>
+      <label><input type="checkbox" id="include-no-seats"> Include sold out</label>
+      <label><input type="checkbox" id="include-waiting"> Include waiting list</label>
+      <button type="submit">Search</button>
+    </form>
+    <ul id="train-list"></ul>
+  </section>
+
+  <section id="reservations" class="view hidden">
+    <h2>Reservations</h2>
+    <button id="refresh-reservations">Refresh</button>
+    <ul id="reservations-list"></ul>
+  </section>
+
+  <section id="settings" class="view hidden">
+    <h2>Settings</h2>
+    <h3>Card</h3>
+    <form id="card-form">
+      <label>Number <input id="card-number" required></label>
+      <label>Password <input id="card-password" required></label>
+      <label>Birthday <input id="card-birthday" required></label>
+      <label>Expire <input id="card-expire" required></label>
+      <button type="submit">Save Card</button>
+    </form>
+    <h3>Telegram</h3>
+    <form id="telegram-form">
+      <label>Token <input id="telegram-token" required></label>
+      <label>Chat ID <input id="telegram-chat" required></label>
+      <button type="submit">Save Telegram</button>
+    </form>
+    <h3>Stations</h3>
+    <form id="station-form">
+      <label>Rail Type
+        <select id="station-rail">
+          <option value="SRT">SRT</option>
+          <option value="KTX">KTX</option>
+        </select>
+      </label>
+      <label>Stations (comma separated)
+        <input id="station-list">
+      </label>
+      <button type="submit">Save Stations</button>
+    </form>
+    <h3>Options</h3>
+    <form id="option-form">
+      <label>Options (comma separated)
+        <input id="option-list">
+      </label>
+      <button type="submit">Save Options</button>
+    </form>
+  </section>
+</main>
+
+<div id="messages"></div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -1,0 +1,148 @@
+let token = localStorage.getItem('token') || '';
+
+document.getElementById('auth-token').value = token;
+document.getElementById('save-token').onclick = () => {
+  token = document.getElementById('auth-token').value.trim();
+  localStorage.setItem('token', token);
+  showMessage('Token saved');
+};
+
+function api(path, options = {}) {
+  options.headers = options.headers || {};
+  options.headers['Content-Type'] = 'application/json';
+  options.headers['X-Auth-Token'] = token;
+  return fetch(path, options).then(r => r.json());
+}
+
+function showMessage(msg) {
+  const box = document.getElementById('messages');
+  box.textContent = msg;
+  setTimeout(() => box.textContent = '', 4000);
+}
+
+function setActive(view) {
+  document.querySelectorAll('nav button').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.view === view);
+  });
+  document.querySelectorAll('main .view').forEach(s => {
+    s.classList.toggle('hidden', s.id !== view);
+  });
+}
+
+document.getElementById('nav').addEventListener('click', e => {
+  if (e.target.dataset.view) setActive(e.target.dataset.view);
+});
+
+// Login
+const loginForm = document.getElementById('login-form');
+loginForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const data = {
+    id: document.getElementById('login-id').value,
+    password: document.getElementById('login-password').value,
+    rail_type: document.getElementById('login-rail').value
+  };
+  api('/login', {method:'POST', body: JSON.stringify(data)}).then(res => {
+    if (res.message === 'ok') showMessage('Login saved');
+    else showMessage(res.message || 'Error');
+  });
+});
+
+// Search
+const searchForm = document.getElementById('search-form');
+searchForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const params = new URLSearchParams({
+    departure: document.getElementById('search-departure').value,
+    arrival: document.getElementById('search-arrival').value,
+    date: document.getElementById('search-date').value.replaceAll('-',''),
+    time: document.getElementById('search-time').value.replace(':','')+'00',
+    rail_type: document.getElementById('search-rail').value,
+    include_no_seats: document.getElementById('include-no-seats').checked,
+    include_waiting_list: document.getElementById('include-waiting').checked
+  });
+  fetch('/reserve?'+params.toString(), {headers:{'X-Auth-Token':token}})
+    .then(r=>r.json()).then(showTrains);
+});
+
+function showTrains(list) {
+  const ul = document.getElementById('train-list');
+  ul.innerHTML = '';
+  list.forEach(train => {
+    const li = document.createElement('li');
+    li.textContent = `[${train.train_number}] ${train.dep_time} - ${train.arr_time}`;
+    const btn = document.createElement('button');
+    btn.textContent = 'Reserve';
+    btn.onclick = () => reserveTrain(train);
+    li.appendChild(btn);
+    ul.appendChild(li);
+  });
+}
+
+function reserveTrain(train) {
+  if (navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({
+      type:'reserve',
+      payload:{
+        token,
+        data:{
+          departure: document.getElementById('search-departure').value,
+          arrival: document.getElementById('search-arrival').value,
+          date: document.getElementById('search-date').value.replaceAll('-',''),
+          time: train.dep_time,
+          rail_type: document.getElementById('search-rail').value
+        }
+      }
+    });
+    showMessage('Reservation started in background');
+  }
+}
+
+// Reservations
+function loadReservations() {
+  fetch('/reservations?rail_type=SRT', {headers:{'X-Auth-Token':token}})
+    .then(r=>r.json()).then(list=>{
+      const ul = document.getElementById('reservations-list');
+      ul.innerHTML='';
+      list.forEach(r=>{
+        const li=document.createElement('li');
+        li.textContent = r.reservation_number || JSON.stringify(r);
+        const btn=document.createElement('button');
+        btn.textContent='Cancel';
+        btn.onclick=()=>cancelReservation(r.reservation_number);
+        li.appendChild(btn);
+        ul.appendChild(li);
+      });
+    });
+}
+
+document.getElementById('refresh-reservations').onclick=loadReservations;
+
+function cancelReservation(pnr){
+  fetch('/reservations/'+pnr+'?rail_type=SRT',{method:'DELETE',headers:{'X-Auth-Token':token}})
+    .then(r=>r.json()).then(res=>{showMessage(res.message);loadReservations();});
+}
+
+// Settings forms
+function simpleForm(id, path) {
+  document.getElementById(id).addEventListener('submit', e => {
+    e.preventDefault();
+    const data = {};
+    new FormData(e.target).forEach((v,k)=>data[k]=v);
+    api(path,{method:'POST',body:JSON.stringify(data)}).then(res=>showMessage(res.message));
+  });
+}
+
+simpleForm('card-form','/settings/card');
+simpleForm('telegram-form','/settings/telegram');
+simpleForm('station-form','/settings/stations');
+simpleForm('option-form','/settings/options');
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js');
+  navigator.serviceWorker.addEventListener('message', e => {
+    if (e.data.type === 'reserve-result') {
+      showMessage(e.data.success ? 'Reservation complete' : 'Reservation failed');
+    }
+  });
+}

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,38 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+header nav {
+  display: flex;
+  background: #333;
+}
+nav button {
+  flex: 1;
+  padding: 1em;
+  background: none;
+  color: #fff;
+  border: none;
+  font-size: 1em;
+}
+nav button.active {
+  background: #555;
+}
+.token-box, #token-box {
+  padding: 0.5em;
+  background: #444;
+  color: #fff;
+  text-align: center;
+}
+.view {
+  padding: 1em;
+}
+.hidden {
+  display: none;
+}
+#train-list li, #reservations-list li {
+  padding: 0.5em 0;
+  border-bottom: 1px solid #ddd;
+}
+@media (min-width: 600px) {
+  nav button { flex: none; }
+}

--- a/webapp/static/sw.js
+++ b/webapp/static/sw.js
@@ -1,0 +1,34 @@
+self.addEventListener('install', e => self.skipWaiting());
+self.addEventListener('activate', e => self.clients.claim());
+
+let controller = null;
+
+self.addEventListener('message', event => {
+  if (event.data.type === 'reserve') {
+    controller = new AbortController();
+    reserve(event.data.payload, event.source);
+  } else if (event.data.type === 'cancel' && controller) {
+    controller.abort();
+  }
+});
+
+async function reserve(payload, source) {
+  try {
+    const resp = await fetch('/reserve', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Auth-Token': payload.token
+      },
+      body: JSON.stringify(payload.data),
+      signal: controller.signal
+    });
+    const data = await resp.json();
+    self.registration.showNotification('Reservation complete');
+    if (source) source.postMessage({type:'reserve-result', success:true, data});
+  } catch (err) {
+    if (err.name === 'AbortError') return;
+    self.registration.showNotification('Reservation failed');
+    if (source) source.postMessage({type:'reserve-result', success:false, error:err.toString()});
+  }
+}


### PR DESCRIPTION
## Summary
- serve static frontend from Flask
- implement a simple responsive UI for login, search/reserve, reservation list, and settings
- save auth token in browser storage
- register a service worker so reservations continue even if the page closes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842169626608325bf408b96ca54012b