### PR TITLE
Add modern frontend with full reservation controls

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,7 +1,7 @@
 import functools
 import secrets
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
 from flasgger import Swagger
 import keyring
 from keyring.errors import KeyringError
@@ -18,7 +18,7 @@ from srtgo.core import (
     set_option_settings,
 )
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder="static", static_url_path="")
 Swagger(app)
 
 TOKEN_SERVICE = "webapp"
@@ -41,6 +41,11 @@ def _ensure_token() -> str:
 
 
 AUTH_TOKEN = _ensure_token()
+
+
+@app.get("/")
+def index_page():
+    return app.send_static_file("index.html")
 
 
 def require_auth(func):

--- a/webapp/static/index.html
+++ b/webapp/static/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>SRTgo Web</title>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">SRTgo</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbar">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0" id="nav">
+        <li class="nav-item"><a class="nav-link active" href="#" data-view="login">Login</a></li>
+        <li class="nav-item"><a class="nav-link" href="#" data-view="search">Search</a></li>
+        <li class="nav-item"><a class="nav-link" href="#" data-view="reservations">Reservations</a></li>
+        <li class="nav-item"><a class="nav-link" href="#" data-view="settings">Settings</a></li>
+      </ul>
+      <div class="d-flex align-items-center" id="token-box">
+        <input id="auth-token" class="form-control form-control-sm me-2" placeholder="Auth Token">
+        <button id="save-token" class="btn btn-light btn-sm me-2">Save</button>
+        <button id="reset-token" class="btn btn-warning btn-sm">Reset</button>
+      </div>
+    </div>
+  </div>
+</nav>
+<div id="messages" class="text-center text-danger mt-2"></div>
+<div class="container py-3">
+  <section id="login" class="view">
+    <h2>Login</h2>
+    <form id="login-form" class="row g-2">
+      <div class="col-md-4">
+        <label class="form-label">User ID
+          <input id="login-id" class="form-control" required>
+        </label>
+      </div>
+      <div class="col-md-4">
+        <label class="form-label">Password
+          <input id="login-password" type="password" class="form-control" required>
+        </label>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Rail Type
+          <select id="login-rail" class="form-select">
+            <option value="SRT">SRT</option>
+            <option value="KTX">KTX</option>
+          </select>
+        </label>
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </section>
+
+  <section id="search" class="view d-none">
+    <h2>Search Trains</h2>
+    <form id="search-form" class="row g-2">
+      <div class="col-md-3">
+        <label class="form-label">Departure
+          <input id="search-departure" class="form-control" required>
+        </label>
+      </div>
+      <div class="col-md-3">
+        <label class="form-label">Arrival
+          <input id="search-arrival" class="form-control" required>
+        </label>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Date
+          <input id="search-date" type="date" class="form-control" required>
+        </label>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Time
+          <input id="search-time" type="time" class="form-control" value="00:00">
+        </label>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Rail Type
+          <select id="search-rail" class="form-select">
+            <option value="SRT">SRT</option>
+            <option value="KTX">KTX</option>
+          </select>
+        </label>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Seat
+          <select id="seat-type" class="form-select">
+            <option value="">Default</option>
+            <option value="GENERAL_ONLY">General Only</option>
+            <option value="GENERAL_FIRST">General First</option>
+            <option value="SPECIAL_ONLY">Special Only</option>
+            <option value="SPECIAL_FIRST">Special First</option>
+          </select>
+        </label>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Adult
+          <input id="adult-count" type="number" class="form-control" value="1" min="0">
+        </label>
+      </div>
+      <div class="col-md-2">
+        <label class="form-label">Child
+          <input id="child-count" type="number" class="form-control" value="0" min="0">
+        </label>
+      </div>
+      <div class="col-md-2 form-check align-self-end">
+        <input id="pay-now" type="checkbox" class="form-check-input">
+        <label for="pay-now" class="form-check-label">Pay Now</label>
+      </div>
+      <div class="col-md-2 form-check align-self-end">
+        <input type="checkbox" id="include-no-seats" class="form-check-input">
+        <label for="include-no-seats" class="form-check-label">Include sold out</label>
+      </div>
+      <div class="col-md-2 form-check align-self-end">
+        <input type="checkbox" id="include-waiting" class="form-check-input">
+        <label for="include-waiting" class="form-check-label">Include waiting</label>
+      </div>
+      <div class="col-12">
+        <button type="submit" class="btn btn-primary">Search</button>
+        <button type="button" id="cancel-bg" class="btn btn-secondary ms-2 d-none">Cancel Background</button>
+      </div>
+    </form>
+    <ul id="train-list" class="list-group mt-3"></ul>
+  </section>
+
+  <section id="reservations" class="view d-none">
+    <h2>Reservations</h2>
+    <div class="row g-2 align-items-end">
+      <div class="col-auto">
+        <label class="form-label">Rail Type
+          <select id="res-rail" class="form-select">
+            <option value="SRT">SRT</option>
+            <option value="KTX">KTX</option>
+          </select>
+        </label>
+      </div>
+      <div class="col-auto">
+        <button id="refresh-reservations" class="btn btn-secondary">Refresh</button>
+      </div>
+    </div>
+    <ul id="reservations-list" class="list-group mt-3"></ul>
+  </section>
+
+  <section id="settings" class="view d-none">
+    <h2>Settings</h2>
+    <h3>Card</h3>
+    <form id="card-form" class="row g-2">
+      <div class="col-md-3"><input id="card-number" class="form-control" placeholder="Number" required></div>
+      <div class="col-md-2"><input id="card-password" class="form-control" placeholder="Password" required></div>
+      <div class="col-md-2"><input id="card-birthday" class="form-control" placeholder="Birthday" required></div>
+      <div class="col-md-2"><input id="card-expire" class="form-control" placeholder="Expire" required></div>
+      <div class="col-md-2"><button type="submit" class="btn btn-primary">Save Card</button></div>
+    </form>
+    <h3>Telegram</h3>
+    <form id="telegram-form" class="row g-2">
+      <div class="col-md-4"><input id="telegram-token" class="form-control" placeholder="Token" required></div>
+      <div class="col-md-3"><input id="telegram-chat" class="form-control" placeholder="Chat ID" required></div>
+      <div class="col-md-2"><button type="submit" class="btn btn-primary">Save Telegram</button></div>
+    </form>
+    <h3>Stations</h3>
+    <form id="station-form" class="row g-2">
+      <div class="col-md-2">
+        <select id="station-rail" class="form-select">
+          <option value="SRT">SRT</option>
+          <option value="KTX">KTX</option>
+        </select>
+      </div>
+      <div class="col-md-6"><input id="station-list" class="form-control" placeholder="A,B,C"></div>
+      <div class="col-md-2"><button type="submit" class="btn btn-primary">Save Stations</button></div>
+    </form>
+    <h3>Options</h3>
+    <form id="option-form" class="row g-2">
+      <div class="col-md-6"><input id="option-list" class="form-control" placeholder="opt1,opt2"></div>
+      <div class="col-md-2"><button type="submit" class="btn btn-primary">Save Options</button></div>
+    </form>
+  </section>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="main.js"></script>
+</body>
+</html>

--- a/webapp/static/main.js
+++ b/webapp/static/main.js
@@ -1,0 +1,179 @@
+let token = localStorage.getItem('token') || '';
+const tokenInput = document.getElementById('auth-token');
+tokenInput.value = token;
+document.getElementById('save-token').onclick = () => {
+  token = tokenInput.value.trim();
+  localStorage.setItem('token', token);
+  showMessage('Token saved');
+};
+document.getElementById('reset-token').onclick = () => {
+  api('/token', {method: 'POST'}).then(res => {
+    if (res.token) {
+      token = res.token;
+      tokenInput.value = token;
+      localStorage.setItem('token', token);
+      showMessage('New token issued');
+    }
+  });
+};
+
+function api(path, options = {}) {
+  options.headers = options.headers || {};
+  options.headers['Content-Type'] = 'application/json';
+  options.headers['X-Auth-Token'] = token;
+  return fetch(path, options).then(r => r.json());
+}
+
+function showMessage(msg) {
+  const box = document.getElementById('messages');
+  box.textContent = msg;
+  setTimeout(() => box.textContent = '', 4000);
+}
+
+function setActive(view) {
+  document.querySelectorAll('#nav .nav-link').forEach(a => {
+    a.classList.toggle('active', a.dataset.view === view);
+  });
+  document.querySelectorAll('.view').forEach(s => {
+    s.classList.toggle('d-none', s.id !== view);
+  });
+}
+
+document.getElementById('nav').addEventListener('click', e => {
+  if (e.target.dataset.view) setActive(e.target.dataset.view);
+});
+
+// Login
+const loginForm = document.getElementById('login-form');
+loginForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const data = {
+    id: document.getElementById('login-id').value,
+    password: document.getElementById('login-password').value,
+    rail_type: document.getElementById('login-rail').value
+  };
+  api('/login', {method:'POST', body: JSON.stringify(data)}).then(res => {
+    if (res.message === 'ok') showMessage('Login saved');
+    else showMessage(res.message || 'Error');
+  });
+});
+
+// Search
+const searchForm = document.getElementById('search-form');
+searchForm.addEventListener('submit', e => {
+  e.preventDefault();
+  const params = new URLSearchParams({
+    departure: document.getElementById('search-departure').value,
+    arrival: document.getElementById('search-arrival').value,
+    date: document.getElementById('search-date').value.replaceAll('-',''),
+    time: document.getElementById('search-time').value.replace(':','')+'00',
+    rail_type: document.getElementById('search-rail').value,
+    include_no_seats: document.getElementById('include-no-seats').checked,
+    include_waiting_list: document.getElementById('include-waiting').checked
+  });
+  fetch('/reserve?'+params.toString(), {headers:{'X-Auth-Token':token}})
+    .then(r=>r.json()).then(showTrains);
+});
+
+function showTrains(list) {
+  const ul = document.getElementById('train-list');
+  ul.innerHTML = '';
+  list.forEach(train => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item d-flex justify-content-between align-items-center';
+    li.textContent = `[${train.train_number}] ${train.dep_time} - ${train.arr_time}`;
+    const btn = document.createElement('button');
+    btn.className = 'btn btn-sm btn-outline-primary';
+    btn.textContent = 'Reserve';
+    btn.onclick = () => reserveTrain(train);
+    li.appendChild(btn);
+    ul.appendChild(li);
+  });
+}
+
+function reserveTrain(train) {
+  if (navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({
+      type:'reserve',
+      payload:{
+        token,
+        data:{
+          departure: document.getElementById('search-departure').value,
+          arrival: document.getElementById('search-arrival').value,
+          date: document.getElementById('search-date').value.replaceAll('-',''),
+          time: train.dep_time,
+          rail_type: document.getElementById('search-rail').value,
+          seat_type: document.getElementById('seat-type').value,
+          passengers:{
+            adult: document.getElementById('adult-count').value,
+            child: document.getElementById('child-count').value
+          },
+          pay: document.getElementById('pay-now').checked
+        }
+      }
+    });
+    document.getElementById('cancel-bg').classList.remove('d-none');
+    showMessage('Reservation started in background');
+  }
+}
+
+// Reservations
+function loadReservations() {
+  const rail = document.getElementById('res-rail').value;
+  fetch('/reservations?rail_type='+rail, {headers:{'X-Auth-Token':token}})
+    .then(r=>r.json()).then(list=>{
+      const ul = document.getElementById('reservations-list');
+      ul.innerHTML='';
+      list.forEach(r=>{
+        const li=document.createElement('li');
+        li.className='list-group-item d-flex justify-content-between align-items-center';
+        li.textContent = r.reservation_number || JSON.stringify(r);
+        const btn=document.createElement('button');
+        btn.className='btn btn-sm btn-outline-danger';
+        btn.textContent='Cancel';
+        btn.onclick=()=>cancelReservation(r.reservation_number);
+        li.appendChild(btn);
+        ul.appendChild(li);
+      });
+    });
+}
+
+document.getElementById('refresh-reservations').onclick=loadReservations;
+
+document.getElementById('cancel-bg').onclick = () => {
+  if (navigator.serviceWorker.controller) {
+    navigator.serviceWorker.controller.postMessage({type:'cancel'});
+    document.getElementById('cancel-bg').classList.add('d-none');
+  }
+};
+
+function cancelReservation(pnr){
+  const rail = document.getElementById('res-rail').value;
+  fetch('/reservations/'+pnr+'?rail_type='+rail,{method:'DELETE',headers:{'X-Auth-Token':token}})
+    .then(r=>r.json()).then(res=>{showMessage(res.message);loadReservations();});
+}
+
+// Settings forms
+function simpleForm(id, path) {
+  document.getElementById(id).addEventListener('submit', e => {
+    e.preventDefault();
+    const data = {};
+    new FormData(e.target).forEach((v,k)=>data[k]=v);
+    api(path,{method:'POST',body:JSON.stringify(data)}).then(res=>showMessage(res.message));
+  });
+}
+
+simpleForm('card-form','/settings/card');
+simpleForm('telegram-form','/settings/telegram');
+simpleForm('station-form','/settings/stations');
+simpleForm('option-form','/settings/options');
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js');
+  navigator.serviceWorker.addEventListener('message', e => {
+    if (e.data.type === 'reserve-result') {
+      document.getElementById('cancel-bg').classList.add('d-none');
+      showMessage(e.data.success ? 'Reservation complete' : 'Reservation failed');
+    }
+  });
+}

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,2 @@
+.view.d-none { display: none; }
+#messages { min-height: 1.5em; }

--- a/webapp/static/sw.js
+++ b/webapp/static/sw.js
@@ -1,0 +1,34 @@
+self.addEventListener('install', e => self.skipWaiting());
+self.addEventListener('activate', e => self.clients.claim());
+
+let controller = null;
+
+self.addEventListener('message', event => {
+  if (event.data.type === 'reserve') {
+    controller = new AbortController();
+    event.waitUntil(reserve(event.data.payload, event.source));
+  } else if (event.data.type === 'cancel' && controller) {
+    controller.abort();
+  }
+});
+
+async function reserve(payload, source) {
+  try {
+    const resp = await fetch('/reserve', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Auth-Token': payload.token
+      },
+      body: JSON.stringify(payload.data),
+      signal: controller.signal
+    });
+    const data = await resp.json();
+    self.registration.showNotification('Reservation complete');
+    if (source) source.postMessage({type:'reserve-result', success:true, data});
+  } catch (err) {
+    if (err.name === 'AbortError') return;
+    self.registration.showNotification('Reservation failed');
+    if (source) source.postMessage({type:'reserve-result', success:false, error:err.toString()});
+  }
+}


### PR DESCRIPTION
## Summary
- revamp static index with Bootstrap UI for modern styling
- expose seat type, passenger count, and pay options when reserving
- allow selecting rail type for reservations list
- add ability to reset auth token and cancel background reservations
- enhance service worker for long running requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842169626608325bf408b96ca54012b